### PR TITLE
Bump dash-auth version to fix startup error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dash==0.21.0
-dash-auth==1.0.0
+dash-auth==1.0.1
 dash-renderer==0.11.3
 dash-core-components==0.21.0
 dash-html-components==0.9.0


### PR DESCRIPTION
`Exception: There are more than one oauth apps with the name workshop.` was raised on startup under some conditions due to a race condition. The new `dash-auth` handles this case, allowing the app to start.

@chriddyp Please review

* [x] Tested with Dash On Premise