### PR TITLE
Add example liveness and readiness probes

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,31 @@
+{
+	"healthchecks": {
+		"web": {
+			"readiness": {
+				"httpGet": {
+					"path": "/{{ $APP }}/_dash_layout",
+					"port": 5000
+				},
+				"initialDelaySeconds": 5,
+				"periodSeconds": 5
+			}
+		},
+		"*": {
+			"liveness": {
+				"exec": {
+					"command": ["/bin/pidof", "/start"]
+				},
+				"initialDelaySeconds": 5,
+				"periodSeconds": 5
+			},
+			"readiness": {
+				"httpGet": {
+					"path": "web processes override this.",
+					"port": 5000
+				},
+				"initialDelaySeconds": 5,
+				"periodSeconds": 5
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is not expected to do anything with the currently available version of Dash On-Premise, but will eventually allow highly available Kubernetes-based deployments of Dash On-Premise to react correctly when a Dash app is not ready to receive traffic or is unhealthy enough that it needs to be deleted and restarted by Kubernetes.

CC @plotly/devops. @cldougl please review and please tag anyone else appropriate.